### PR TITLE
Add gene-to-disease associations derived from variant data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,14 @@ test: download
 download:
 	$(RUN) ingest download
 
+.PHONY: preprocess
+preprocess: download
+	$(RUN) python scripts/aggregate_gene_disease.py
+
 .PHONY: run
-run: download
-	$(RUN) ingest transform
+run: preprocess
+	$(RUN) koza transform --source ./src/clingen_ingest/transform.yaml --output-format tsv
+	$(RUN) koza transform --source ./src/clingen_ingest/gene_disease_transform.yaml --output-format tsv
 	$(RUN) python scripts/generate-report.py
 
 

--- a/scripts/aggregate_gene_disease.py
+++ b/scripts/aggregate_gene_disease.py
@@ -1,0 +1,63 @@
+"""Aggregate ClinGen variant data to gene-disease associations using DuckDB."""
+
+import duckdb
+from pathlib import Path
+
+INPUT_FILE = Path("data/clingen_variants.tsv")
+OUTPUT_FILE = Path("data/clingen_gene_disease.tsv")
+
+
+def aggregate_gene_disease():
+    """
+    Aggregate variant-disease associations to gene-disease associations.
+
+    For each unique (gene, disease) pair, determines the strongest assertion
+    from all variants:
+    - Pathogenic > Likely Pathogenic
+    - Skips Uncertain Significance, Benign, Likely Benign, and retracted variants
+    """
+    con = duckdb.connect()
+
+    # Write to TSV using COPY
+    OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    con.execute(f"""
+        COPY (
+            SELECT
+                "HGNC Gene Symbol" AS gene_symbol,
+                "Mondo Id" AS mondo_id,
+                "Disease" AS disease_name,
+                CASE
+                    WHEN MAX(CASE WHEN "Assertion" = 'Pathogenic' THEN 1 ELSE 0 END) = 1
+                    THEN 'Pathogenic'
+                    ELSE 'Likely Pathogenic'
+                END AS strongest_assertion
+            FROM read_csv_auto('{INPUT_FILE}', delim='\t', header=true)
+            WHERE "Assertion" IN ('Pathogenic', 'Likely Pathogenic')
+              AND "Retracted" != 'true'
+              AND "HGNC Gene Symbol" != 'N/A'
+              AND "HGNC Gene Symbol" != ''
+              AND "Mondo Id" != ''
+            GROUP BY "HGNC Gene Symbol", "Mondo Id", "Disease"
+            ORDER BY "HGNC Gene Symbol", "Mondo Id"
+        ) TO '{OUTPUT_FILE}' (HEADER, DELIMITER '\t')
+    """)
+
+    # Report counts
+    count_result = con.execute(f"SELECT COUNT(*) FROM read_csv_auto('{OUTPUT_FILE}', delim='\\t', header=true)")
+    count = count_result.fetchone()[0]
+    print(f"Aggregated to {count} unique gene-disease associations")
+
+    # Count by assertion type
+    assertion_counts = con.execute(f"""
+        SELECT strongest_assertion, COUNT(*) as count
+        FROM read_csv_auto('{OUTPUT_FILE}', delim='\\t', header=true)
+        GROUP BY strongest_assertion
+    """).fetchall()
+    for assertion, cnt in assertion_counts:
+        print(f"  {assertion}: {cnt}")
+
+    con.close()
+
+
+if __name__ == "__main__":
+    aggregate_gene_disease()

--- a/src/clingen_ingest/gene_disease_transform.py
+++ b/src/clingen_ingest/gene_disease_transform.py
@@ -1,0 +1,54 @@
+"""Koza transform for gene-to-disease associations from aggregated ClinGen data."""
+
+import uuid
+
+from biolink_model.datamodel.pydanticmodel_v2 import (
+    AgentTypeEnum,
+    CausalGeneToDiseaseAssociation,
+    KnowledgeLevelEnum,
+)
+from koza.cli_utils import get_koza_app
+
+koza_app = get_koza_app("clingen_gene_disease")
+hgnc_gene_lookup = koza_app.get_map("hgnc_gene_lookup")
+
+# Gene to disease predicates (matching variant-to-disease predicates)
+CAUSES = "biolink:causes"
+ASSOCIATED_WITH_INCREASED_LIKELIHOOD = "biolink:associated_with_increased_likelihood_of"
+
+
+def get_predicate(assertion: str) -> str:
+    """Get the predicate based on strongest assertion level."""
+    if assertion == "Pathogenic":
+        return CAUSES
+    elif assertion == "Likely Pathogenic":
+        return ASSOCIATED_WITH_INCREASED_LIKELIHOOD
+    else:
+        raise ValueError(f"Unexpected assertion: '{assertion}'")
+
+
+while (row := koza_app.get_row()) is not None:
+    gene_symbol = row["gene_symbol"]
+    mondo_id = row["mondo_id"]
+    strongest_assertion = row["strongest_assertion"]
+
+    # Look up HGNC gene ID
+    if gene_symbol not in hgnc_gene_lookup:
+        continue
+    gene_id = hgnc_gene_lookup[gene_symbol]["hgnc_id"]
+
+    predicate = get_predicate(strongest_assertion)
+
+    association = CausalGeneToDiseaseAssociation(
+        id=str(uuid.uuid4()),
+        subject=gene_id,
+        predicate=predicate,
+        object=mondo_id,
+        original_predicate=strongest_assertion,
+        primary_knowledge_source="infores:clingen",
+        aggregator_knowledge_source=["infores:monarchinitiative"],
+        knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+        agent_type=AgentTypeEnum.manual_agent,
+    )
+
+    koza_app.write(association)

--- a/src/clingen_ingest/gene_disease_transform.yaml
+++ b/src/clingen_ingest/gene_disease_transform.yaml
@@ -1,0 +1,35 @@
+# Config file for transforming aggregated gene-disease data
+# See additional/optional config parameters at https://koza.monarchinitiative.org/Ingests/source_config/
+
+name: "clingen_gene_disease"
+metadata: "./src/clingen_ingest/metadata.yaml"
+format: "csv"
+delimiter: "\t"
+files:
+  - "./data/clingen_gene_disease.tsv"
+
+depends_on:
+  - "./src/clingen_ingest/hgnc_gene_lookup.yaml"
+
+columns:
+  - gene_symbol
+  - mondo_id
+  - disease_name
+  - strongest_assertion
+
+edge_properties:
+  - id
+  - subject
+  - predicate
+  - object
+  - original_predicate
+  - category
+  - knowledge_level
+  - agent_type
+  - primary_knowledge_source
+  - aggregator_knowledge_source
+
+# Minimum expected edges (expecting ~193 g2d associations)
+min_edge_count: 100
+
+header: 0

--- a/tests/test_gene_disease_transform.py
+++ b/tests/test_gene_disease_transform.py
@@ -1,0 +1,113 @@
+"""
+Tests for the gene-to-disease transform.
+
+Tests the transformation of aggregated gene-disease data to
+CausalGeneToDiseaseAssociation entities.
+"""
+
+import pytest
+from koza.utils.testing_utils import mock_koza
+
+mock_koza = mock_koza  # Prevent removal on formatting
+
+# Define the ingest name and transform script path
+INGEST_NAME = "clingen_gene_disease"
+TRANSFORM_SCRIPT = "./src/clingen_ingest/gene_disease_transform.py"
+
+
+@pytest.fixture
+def map_cache():
+    """HGNC gene lookup for test genes."""
+    return {
+        "hgnc_gene_lookup": {
+            "PAH": {"hgnc_id": "HGNC:8582"},
+            "BRCA1": {"hgnc_id": "HGNC:1100"},
+        }
+    }
+
+
+@pytest.fixture
+def pathogenic_row():
+    """A row with Pathogenic as strongest assertion."""
+    return {
+        "gene_symbol": "PAH",
+        "mondo_id": "MONDO:0009861",
+        "disease_name": "phenylketonuria",
+        "strongest_assertion": "Pathogenic",
+    }
+
+
+@pytest.fixture
+def likely_pathogenic_row():
+    """A row with Likely Pathogenic as strongest assertion."""
+    return {
+        "gene_symbol": "BRCA1",
+        "mondo_id": "MONDO:0016419",
+        "disease_name": "hereditary breast cancer",
+        "strongest_assertion": "Likely Pathogenic",
+    }
+
+
+@pytest.fixture
+def unknown_gene_row():
+    """A row with a gene not in HGNC lookup."""
+    return {
+        "gene_symbol": "UNKNOWN_GENE",
+        "mondo_id": "MONDO:0000001",
+        "disease_name": "some disease",
+        "strongest_assertion": "Pathogenic",
+    }
+
+
+@pytest.fixture
+def pathogenic_entities(mock_koza, pathogenic_row, map_cache):
+    return mock_koza(INGEST_NAME, pathogenic_row, TRANSFORM_SCRIPT, map_cache=map_cache)
+
+
+@pytest.fixture
+def likely_pathogenic_entities(mock_koza, likely_pathogenic_row, map_cache):
+    return mock_koza(INGEST_NAME, likely_pathogenic_row, TRANSFORM_SCRIPT, map_cache=map_cache)
+
+
+@pytest.fixture
+def unknown_gene_entities(mock_koza, unknown_gene_row, map_cache):
+    return mock_koza(INGEST_NAME, unknown_gene_row, TRANSFORM_SCRIPT, map_cache=map_cache)
+
+
+def test_pathogenic_assertion(pathogenic_entities):
+    """Test that Pathogenic assertion produces biolink:causes predicate."""
+    assert len(pathogenic_entities) == 1
+    association = pathogenic_entities[0]
+
+    assert association.subject == "HGNC:8582"
+    assert association.predicate == "biolink:causes"
+    assert association.object == "MONDO:0009861"
+    assert association.original_predicate == "Pathogenic"
+    assert association.primary_knowledge_source == "infores:clingen"
+    assert association.aggregator_knowledge_source == ["infores:monarchinitiative"]
+    assert association.knowledge_level == "knowledge_assertion"
+    assert association.agent_type == "manual_agent"
+
+
+def test_likely_pathogenic_assertion(likely_pathogenic_entities):
+    """Test that Likely Pathogenic produces associated_with_increased_likelihood_of."""
+    assert len(likely_pathogenic_entities) == 1
+    association = likely_pathogenic_entities[0]
+
+    assert association.subject == "HGNC:1100"
+    assert association.predicate == "biolink:associated_with_increased_likelihood_of"
+    assert association.object == "MONDO:0016419"
+    assert association.original_predicate == "Likely Pathogenic"
+
+
+def test_unknown_gene_skipped(unknown_gene_entities):
+    """Test that rows with unknown genes are skipped."""
+    assert len(unknown_gene_entities) == 0
+
+
+def test_invalid_assertion(mock_koza, pathogenic_row, map_cache):
+    """Test that invalid assertions raise ValueError."""
+    pathogenic_row["strongest_assertion"] = "Invalid"
+    with pytest.raises(ValueError) as e_info:
+        mock_koza(INGEST_NAME, pathogenic_row, TRANSFORM_SCRIPT, map_cache=map_cache)
+    assert "Unexpected assertion" in str(e_info.value)


### PR DESCRIPTION
## Summary
- Adds gene-to-disease (g2d) associations derived from ClinGen variant-disease data
- Uses DuckDB to aggregate variants by (gene, disease) pair, taking the strongest assertion
- Produces 193 `CausalGeneToDiseaseAssociation` edges

## Predicate Mapping
| Strongest Variant Assertion | Predicate |
|---|---|
| Pathogenic | `biolink:causes` |
| Likely Pathogenic | `biolink:associated_with_increased_likelihood_of` |
| Uncertain Significance | Skipped |

## Changes
- `scripts/aggregate_gene_disease.py` - DuckDB preprocessing script
- `src/clingen_ingest/gene_disease_transform.py` - Koza transform for g2d
- `src/clingen_ingest/gene_disease_transform.yaml` - Transform config with `min_edge_count: 100`
- `tests/test_gene_disease_transform.py` - 4 new tests
- `Makefile` - Added `preprocess` target as dependency for `run`

## Test plan
- [x] All 14 tests pass (`poetry run pytest tests/ -v`)
- [x] Full pipeline runs successfully (`make run`)
- [x] Output verified: 193 g2d edges (157 causes, 36 associated_with_increased_likelihood_of)

🤖 Generated with [Claude Code](https://claude.com/claude-code)