### PR TITLE
Derive clingen version from max(Published Date)

### DIFF
--- a/src/versions.py
+++ b/src/versions.py
@@ -3,12 +3,20 @@
 Two logical sources:
   - infores:clingen — variant classifications from the clinicalgenome.org API
   - infores:hgnc    — HGNC complete set used for gene symbol → ID mapping
+
+ClinGen's erepo API doesn't surface a snapshot version (no Last-Modified
+header, no version preamble in the file, no /info endpoint). Instead we
+derive a version from the data itself: `max("Published Date")` across
+the TSV. That date moves forward as new classifications are curated and
+agrees across two fetches iff the dataset is unchanged.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+
+import duckdb
 
 from kozahub_metadata_schema import (
     now_iso,
@@ -19,6 +27,23 @@ from kozahub_metadata_schema import (
 
 INGEST_DIR = Path(__file__).resolve().parents[1]
 DOWNLOAD_YAML = INGEST_DIR / "download.yaml"
+CLINGEN_TSV = INGEST_DIR / "data" / "clingen_variants.tsv"
+
+
+def version_from_clingen_tsv(path: Path) -> tuple[str, str]:
+    """Read max(Published Date) from the ClinGen classifications TSV via DuckDB."""
+    if not path.is_file():
+        return "unknown", "unavailable"
+    try:
+        result = duckdb.sql(
+            f"SELECT max(CAST(\"Published Date\" AS DATE)) "
+            f"FROM read_csv_auto('{path.as_posix()}', delim='\\t', header=true)"
+        ).fetchone()
+    except duckdb.Error:
+        return "unknown", "unavailable"
+    if not result or result[0] is None:
+        return "unknown", "unavailable"
+    return result[0].isoformat(), "max_published_date"
 
 
 def get_source_versions() -> list[dict[str, Any]]:
@@ -29,7 +54,7 @@ def get_source_versions() -> list[dict[str, Any]]:
     sources: list[dict[str, Any]] = []
 
     if clingen_urls:
-        ver, method = version_from_http_last_modified(clingen_urls[0])
+        ver, method = version_from_clingen_tsv(CLINGEN_TSV)
         sources.append({
             "id": "infores:clingen",
             "name": "ClinGen — Clinical Genome Resource",


### PR DESCRIPTION
## Summary
ClinGen's erepo API doesn't surface a snapshot version anywhere mechanically readable, so the existing `http_last_modified` probe was always returning `unknown` / `unavailable`. Replace it with a content-derived signal: `max("Published Date")` across the variant classifications TSV, read via DuckDB.

## Test plan
- [x] 14 unit tests pass.
- [x] Local end-to-end: \`just metadata\` produces \`output/release-metadata.yaml\` with \`version: 2026-01-28\`, \`version_method: max_published_date\` for \`infores:clingen\` (was \`unknown\`/\`unavailable\`). \`build_version\` reflects the real upstream version.

A companion change to monarch-ingest classifies \`max_published_date\` as a rolling method (drift bucket), since like \`http_last_modified\` the value naturally rolls forward as the upstream dataset is curated.